### PR TITLE
fix(standardness): use policySettings for RequireStandard check

### DIFF
--- a/core/scriptengine.cpp
+++ b/core/scriptengine.cpp
@@ -10,6 +10,10 @@
 #include <extendedTx.hpp>
 #include <scriptengine.hpp>
 
+// BDK-specific error codes for standardness failures (above bitcoin-sv's SCRIPT_ERR_ERROR_COUNT)
+static constexpr ScriptError SCRIPT_ERR_NON_STANDARD_TX    = static_cast<ScriptError>(200);
+static constexpr ScriptError SCRIPT_ERR_NON_STANDARD_INPUT = static_cast<ScriptError>(201);
+
 bsv::CScriptEngine::CScriptEngine(const std::string chainName)
     : chainParams{ std::move(bsv::CreateCustomChainParams(chainName)) }
     , source{ task::CCancellationSource::Make() }
@@ -337,7 +341,6 @@ uint64_t bsv::CScriptEngine::GetSigOpCount(std::span<const uint8_t> extendedTX, 
 }
 
 // Helper function to perform standardness checks
-// Returns SCRIPT_ERR_OK if all checks pass, otherwise returns SCRIPT_ERR_UNKNOWN_ERROR
 ScriptError checkStandardness(
     const task::CCancellationToken& token,
     const ConfigScriptPolicy& policySettings,
@@ -347,15 +350,11 @@ ScriptError checkStandardness(
     int32_t blockHeight
 )
 {
-    // Check if transaction is standard (IsStandardTx)
     std::string reason;
     if (!IsStandardTx(policySettings, tx, blockHeight, reason)) {
-        // Transaction is not standard
-        return SCRIPT_ERR_UNKNOWN_ERROR;
+        return SCRIPT_ERR_NON_STANDARD_TX;
     }
 
-    // Check if inputs are standard (AreInputsStandard equivalent)
-    // We replicate the logic from AreInputsStandard but use embedded utxos instead of CCoinsViewCache
     if (!tx.IsCoinBase()) {
         constexpr bool consensus = false;
         constexpr uint32_t flags = SCRIPT_VERIFY_NONE;
@@ -368,8 +367,7 @@ ScriptError checkStandardness(
 
             auto result = IsInputStandard(token, params, scriptSig, prevScript, utxoEra, flags);
             if (!result.has_value() || !result.value()) {
-                // Input is not standard or check was cancelled
-                return SCRIPT_ERR_UNKNOWN_ERROR;
+                return SCRIPT_ERR_NON_STANDARD_INPUT;
             }
         }
     }
@@ -407,7 +405,7 @@ ScriptError bsv::CScriptEngine::VerifyScript(std::span<const uint8_t> extendedTX
     const CTransaction ctx(eTX.mtx); // costly conversion due to hash calculation
 
     // Perform standardness checks when consensus=false
-    const bool requireStandard = chainParams->RequireStandard();
+    const bool requireStandard = policySettings.GetRequireStandard();
     if (!consensus && requireStandard) {
         ScriptError standardnessError = checkStandardness(source->GetToken(), policySettings, ctx, eTX, utxoHeights, blockHeight);
         if (standardnessError != SCRIPT_ERR_OK) {

--- a/module/gobdk/bdkcgo/src/script_error_cgo.cpp
+++ b/module/gobdk/bdkcgo/src/script_error_cgo.cpp
@@ -2,6 +2,10 @@
 #include <bdkcgo/script_error_cgo.h>
 
 const char *cgo_script_error_string(const int e) {
+    // BDK-specific error codes for standardness failures
+    if (e == 200) return "non-standard transaction";
+    if (e == 201) return "non-standard input";
+
     if (e > SCRIPT_ERR_ERROR_COUNT) {
         return "CGO EXCEPTION : Exception has been thrown and handled in C/C++ layer";
     }

--- a/module/gobdk/script/scripterror.go
+++ b/module/gobdk/script/scripterror.go
@@ -96,12 +96,25 @@ const (
 	SCRIPT_ERR_CGO_EXCEPTION
 )
 
+// BDK-specific error codes for standardness failures (above bitcoin-sv's enum range)
+const (
+	SCRIPT_ERR_NON_STANDARD_TX    ScriptErrorCode = 200
+	SCRIPT_ERR_NON_STANDARD_INPUT ScriptErrorCode = 201
+)
+
 func CPP_SCRIPT_ERR_ERROR_COUNT() int {
 	return int(C.ScriptEngine_CPP_SCRIPT_ERR_ERROR_COUNT())
 }
 
 // errorCode2String conversion of ScriptErrorCode to string, using C++ code
 func errorCode2String(e ScriptErrorCode) string {
+	switch e {
+	case SCRIPT_ERR_NON_STANDARD_TX:
+		return "non-standard transaction"
+	case SCRIPT_ERR_NON_STANDARD_INPUT:
+		return "non-standard input"
+	}
+
 	if e > SCRIPT_ERR_ERROR_COUNT {
 		return "Exception thrown from C++ code"
 	}


### PR DESCRIPTION
## Summary

- `checkStandardness()` in `scriptengine.cpp` was reading `chainParams->RequireStandard()` (immutable, always `true` for mainnet) instead of `policySettings.GetRequireStandard()` (configurable via `SetRequireStandard()` API). This meant standardness checks always ran for mainnet with `consensus=false`, rejecting valid non-standard txs even when the caller set `SetRequireStandard(false)`.
- Replaced `SCRIPT_ERR_UNKNOWN_ERROR` returns from `checkStandardness()` with specific error codes: `SCRIPT_ERR_NON_STANDARD_TX` (200) and `SCRIPT_ERR_NON_STANDARD_INPUT` (201), with matching error strings in both C++ and Go layers.

## Root cause

```cpp
// Before (bug): reads immutable chain param
const bool requireStandard = chainParams->RequireStandard();

// After (fix): reads configurable policy setting
const bool requireStandard = policySettings.GetRequireStandard();
```

The `SetRequireStandard(bool)` API correctly sets `policySettings`, but the guard condition was reading `chainParams` — a different object.

## Impact

Teranode INV validation uses `consensus=false`. On mainnet, every non-standard tx (e.g. complex scripts, OP_RETURN data carriers) was rejected during pre-validation with `SCRIPT_ERR_UNKNOWN_ERROR`, even though the same txs pass block validation (`consensus=true`). This affected txs in blocks like 945796.

## Test plan

- [ ] Existing `test_script_error.cpp` still passes (error count unchanged)
- [ ] Go `ScriptError_test.go` still passes (iota enum unmodified)
- [ ] Verify `consensus=false` with `SetRequireStandard(false)` no longer rejects valid txs on mainnet
- [ ] Verify new error codes 200/201 produce readable error strings