### PR TITLE
ci: remove macos-15-intel build matrix entries

### DIFF
--- a/.github/workflows/build_bdk.yaml
+++ b/.github/workflows/build_bdk.yaml
@@ -29,7 +29,6 @@ jobs:
           - os: ubuntu-22.04-arm
           - os: ubuntu-22.04
           - os: macos-15
-          - os: macos-15-intel
       fail-fast: false
     outputs:
       modified: ${{ steps.gobdk_change.outputs.modified }}
@@ -114,13 +113,6 @@ jobs:
             echo "DEPENDENCIES_DIR=${{ github.workspace }}/dependancies_darwin_arm64" >> $GITHUB_ENV
             echo "BOOST_ROOT=${{ github.workspace }}/dependancies_darwin_arm64/boost_1.85.0" >> $GITHUB_ENV
             echo "OPENSSL_ROOT_DIR=${{ github.workspace }}/dependancies_darwin_arm64/openssl_3.4.0" >> $GITHUB_ENV
-          fi
-          if [[ "${{ matrix.os }}" == "macos-15-intel" ]]; then
-            wget https://github.com/bitcoin-sv/bdk/releases/download/depcy/dependancies_darwin_x86_64.tar.gz
-            tar -xzf dependancies_darwin_x86_64.tar.gz
-            echo "DEPENDENCIES_DIR=${{ github.workspace }}/dependancies_darwin_x86_64" >> $GITHUB_ENV
-            echo "BOOST_ROOT=${{ github.workspace }}/dependancies_darwin_x86_64/boost_1.85.0" >> $GITHUB_ENV
-            echo "OPENSSL_ROOT_DIR=${{ github.workspace }}/dependancies_darwin_x86_64/openssl_3.4.0" >> $GITHUB_ENV
           fi
 
       - name: Build and Test BDK Unix (all linux and mac arm)

--- a/.github/workflows/prebuild_dependancies.yaml
+++ b/.github/workflows/prebuild_dependancies.yaml
@@ -11,7 +11,6 @@ jobs:
           - os: ubuntu-22.04-arm
           - os: ubuntu-22.04
           - os: macos-15
-          - os: macos-15-intel
       fail-fast: false
     runs-on: ${{ matrix.os }}
 
@@ -55,17 +54,7 @@ jobs:
         wget -q $BOOST_URL -O "boost-$BOOST_VERSION-cmake.tar.gz"
         tar -xzf "boost-$BOOST_VERSION-cmake.tar.gz"
         mkdir -p "boost-$BOOST_VERSION/build"
-        if [[ "${{ matrix.os }}" == "macos-15-intel" ]]; then
-          echo "Force to build boost with arch x86_64 for macos-15 (which is an arm machine) ..."
-
-          ## Build x86_64 on macos-15 requires to skip the Boost:context. There are 2 ways
-          ##   - exclude context and all related dependencies
-          ##   - include only boost modules that are required by bsv (search for AX_BOOST_* in bsv source)
-          #cmake -B "./boost-$BOOST_VERSION/build" -S "./boost-$BOOST_VERSION" -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_PREFIX="$BOOST_ROOT" -DBOOST_EXCLUDE_LIBRARIES="context;asio;cobalt;coroutine;coroutine2;fiber;fiber_numa;log;log_setup" -DCMAKE_OSX_ARCHITECTURES="x86_64"
-          cmake -B "./boost-$BOOST_VERSION/build" -S "./boost-$BOOST_VERSION" -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_PREFIX="$BOOST_ROOT" -DBOOST_INCLUDE_LIBRARIES="chrono;filesystem;program_options;system;test;thread;circular_buffer;multi_index;property_tree;signals2;uuid;variant" -DCMAKE_OSX_ARCHITECTURES="x86_64"
-        else
-          cmake -B "./boost-$BOOST_VERSION/build" -S "./boost-$BOOST_VERSION" -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_PREFIX="$BOOST_ROOT" -DBOOST_INCLUDE_LIBRARIES="chrono;filesystem;program_options;system;test;thread;circular_buffer;multi_index;property_tree;signals2;uuid;variant"
-        fi
+        cmake -B "./boost-$BOOST_VERSION/build" -S "./boost-$BOOST_VERSION" -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_PREFIX="$BOOST_ROOT" -DBOOST_INCLUDE_LIBRARIES="chrono;filesystem;program_options;system;test;thread;circular_buffer;multi_index;property_tree;signals2;uuid;variant"
         cmake --build "./boost-$BOOST_VERSION/build" -j$(nproc) --target install
 
     - name: Build OpenSSL
@@ -74,15 +63,7 @@ jobs:
         tar -xzf "openssl-$OPENSSL_VERSION.tar.gz"
         cd "openssl-$OPENSSL_VERSION"
 
-        if [[ "${{ matrix.os }}" == "macos-15-intel" ]]; then
-          echo "Force to build boost with arch x86_64 for macos-15 (which is an arm machine) ..."
-          export KERNEL_BITS=64
-          export CFLAGS="-arch x86_64"
-          export LDFLAGS="-arch x86_64"
-          ./config darwin64-x86_64-cc no-shared no-tests no-docs no-dso no-engine --prefix="$OPENSSL_ROOT_DIR" --openssldir="$OPENSSL_ROOT_DIR"
-        else
-          ./config no-shared no-tests no-docs no-dso no-engine --prefix="$OPENSSL_ROOT_DIR" --openssldir="$OPENSSL_ROOT_DIR"
-        fi
+        ./config no-shared no-tests no-docs no-dso no-engine --prefix="$OPENSSL_ROOT_DIR" --openssldir="$OPENSSL_ROOT_DIR"
         make -j$(nproc)
         make install_sw
 

--- a/.github/workflows/test_whatever.yaml
+++ b/.github/workflows/test_whatever.yaml
@@ -11,7 +11,6 @@ jobs:
           - os: ubuntu-22.04-arm
           - os: ubuntu-22.04
           - os: macos-15
-          - os: macos-15-intel
       fail-fast: false
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
## Summary

Removes the `macos-15-intel` entry from the `Build BDK`, `Manual Build Dependencies`, and `Test workflow` matrices. The Intel macOS runner is the slowest and most expensive leg of CI without contributing platform coverage that isn't already exercised by the Apple Silicon (`macos-15`) runner.

## Why

`macos-15-intel` is the long-pole job on every workflow run, and macOS minutes bill at **10x** the rate of Linux minutes on GitHub-hosted runners. Removing it cuts both wall-clock CI time and billed compute.

### Per-job duration (7 recent `Build BDK` runs)

| Runner | Avg duration | Range |
|---|---|---|
| `macos-15-intel` | **~17.4 min** | 12.7 – 21.7 min |
| `macos-15` (Apple Silicon) | ~6.8 min | 5.6 – 8.3 min |
| `ubuntu-22.04` | ~7.1 min | 6.2 – 7.6 min |
| `ubuntu-22.04-arm` | ~6.1 min | 6.0 – 6.2 min |

Source: runs `25099239485`, `25109369795`, `25435963361`, `25485061053`, `25486523022`, `25655946940`, `25667993357`.

### Impact per run

- **Wall-clock**: workflow drops from being gated at ~17 min to ~7 min — **~60% faster end-to-end**.
- **Billed minutes**: `macos-15-intel` alone consumes ~174 min-equivalent (17.4 min × 10x macOS multiplier). The remaining matrix totals ~81 min-equivalent (linux 13.2 min × 1 + macos-15 6.8 min × 10). Removing Intel cuts billed minutes by **~68% per run**.
- **macOS minutes specifically**: drops from ~242 min-equivalent (intel + arm) to ~68 min-equivalent — **~72% reduction in macOS spend** while keeping macOS coverage via the arm runner.

The `Manual Build Dependencies` workflow contained an extra arch-specific path for the Intel target (custom Boost `CMAKE_OSX_ARCHITECTURES=x86_64`, OpenSSL `darwin64-x86_64-cc`) which is also removed; the prebuilt `dependancies_darwin_x86_64.tar.gz` artifact is no longer consumed by CI.

## Files changed

- `.github/workflows/build_bdk.yaml` — drop matrix entry + dependency download block
- `.github/workflows/prebuild_dependancies.yaml` — drop matrix entry + intel-specific Boost/OpenSSL branches
- `.github/workflows/test_whatever.yaml` — drop matrix entry

## Test plan

- [ ] CI on this PR passes on the remaining 3 matrix entries
- [ ] Confirm no other workflow consumes the `dependancies_darwin_x86_64` release asset
